### PR TITLE
Fix static file path

### DIFF
--- a/index.js
+++ b/index.js
@@ -91,8 +91,8 @@ app.post('/auth/vk/callback', async (req, res) => {
 }
 });
 
-// Раздача статики (frontend/public) как и раньше — это правильно!
-app.use(express.static(path.join(__dirname, 'frontend')));
+// Раздача статики
+// Если директории "frontend" нет, оставляем только папку "public"
 app.use(express.static(path.join(__dirname, 'public')));
 
 app.listen(PORT, () => {


### PR DESCRIPTION
## Summary
- serve static files only from `public` directory

## Testing
- `node index.js` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_6869497b3b8883218b12d1cb8fbd169c